### PR TITLE
Added min-height property

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
             border-radius: 5px;
             margin: 16px 0;
         }
+        
+        div {
+             min-height: 15px;
+        }
     </style>
 </head>
 


### PR DESCRIPTION
Firefox does not set a min-height for paragraphs automatically. When a div is empty, it has no height therefore a firefox user can't type anything